### PR TITLE
Mnemonic security changes for private network tutorial

### DIFF
--- a/tuts/start-a-private-network/v2.0.0-alpha.6/customchain.md
+++ b/tuts/start-a-private-network/v2.0.0-alpha.6/customchain.md
@@ -61,7 +61,7 @@ You should see the console outputs something as follows:
 Once your node is running, you will again notice that no blocks are being produced. At this point,
 you need to add your keys into the keystore. Remember you will need to complete these steps for each node in your network.
 
-### Option 1: Using Polkadot-JS App UI
+### Add Keys with the Polkadot-JS App UI
 
 You can use the Apps UI to insert your keys into the keystore. Navigate to the "Toolbox" tab and the "RPC Call" sub-tab. Choose "author" and "insertKey". The fields can be filled like this:
 
@@ -86,31 +86,6 @@ publicKey: <your raw ed25519 key> (eg. 0xb48004c6e1625282313b07d1c9950935e86894a
 > If you generated your keys with the Apps UI you will not know your raw public key. In this case you may use your SS58 address (`5G9NWJ5P9uk7am24yCKeLZJqXWW6hjuMyRJDmw4ofqxG8Js2`) instead.
 
 > If you are following these steps for the _second_ node in the network, you must connect the UI to the second node before inserting the keys.
-
-### Option 2: Using CLI
-
-You can also insert a key to the keystore by command line.
-
-```bash
-# Submit a new key via RPC, connect to where your `rpc-port` is listening
-$ curl http://localhost:9933 -H "Content-Type:application/json;charset=utf-8" -d \
-  '{
-    "jsonrpc":"2.0",
-    "id":1,
-    "method":"author_insertKey",
-    "params": [
-      "<aura/gran>",
-      "<mnemonic phrase>",
-      "<public key>"
-    ]
-  }'
-```
-
-If you enter the command and parameters correctly, the node will return a JSON response as follows.
-
-```json
-{ "jsonrpc": "2.0", "result": null, "id": 1 }
-```
 
 ## Subsequent Participants Join
 


### PR DESCRIPTION
The private network tutorial suggested cURL as an option for adding keys to the keystore of a node, but this is potentially insecure because the mnemonic will be stored in the user's bash history.

This addresses #21 