### PR TITLE
Fix system import in struture overview.

### DIFF
--- a/tuts/build-a-dapp/v2.0.0-alpha.6/pallet.md
+++ b/tuts/build-a-dapp/v2.0.0-alpha.6/pallet.md
@@ -127,7 +127,6 @@ default = ['std']
 std = [
     'codec/std',
     'frame-support/std',
-    'safe-mix/std',
     'system/std',
     'sp-std/std',          <-- This line is new
 ]

--- a/tuts/build-a-dapp/v2.0.0-alpha.6/pallet.md
+++ b/tuts/build-a-dapp/v2.0.0-alpha.6/pallet.md
@@ -127,7 +127,7 @@ default = ['std']
 std = [
     'codec/std',
     'frame-support/std',
-    'system/std',
+    'frame-system/std',
     'sp-std/std',          <-- This line is new
 ]
 ```

--- a/tuts/build-a-dapp/v2.0.0-alpha.6/pallet.md
+++ b/tuts/build-a-dapp/v2.0.0-alpha.6/pallet.md
@@ -73,7 +73,7 @@ At a high level, a Substrate pallet can be broken down into six sections:
 ```rust
 // 1. Imports
 use frame_support::{decl_module, decl_storage, decl_event, dispatch::DispatchResult};
-use system::ensure_signed;
+use frame_system::{self as system, ensure_signed};
 
 // 2. Pallet Configuration
 pub trait Trait: system::Trait { /* --snip-- */ }


### PR DESCRIPTION
This PR updates the build a dapp tutorial so that the imports in the block that describes the general structure of a pallet match the ones in the copy-paste-ready code and the node template.